### PR TITLE
Fixing a bug related to zvalues and particle IDs:

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,7 @@
+3.7.1:
+     * fixing a bug related to zvalues and particle IDs:
+        - when the particle set is created from a subset and the ids of the set
+          are not consecutive, cryodrgn fails.
 3.7:
     - drop support for v<1.0.0
     - remove emtable requirement

--- a/cryodrgn/__init__.py
+++ b/cryodrgn/__init__.py
@@ -32,7 +32,7 @@ from pyworkflow import Config
 from .constants import *
 
 
-__version__ = '3.7'
+__version__ = '3.8'
 _references = ['Zhong2020', 'Zhong2021', 'Kinman2022']
 _logo = "cryodrgn_logo.png"
 

--- a/cryodrgn/protocols/protocol_train.py
+++ b/cryodrgn/protocols/protocol_train.py
@@ -273,7 +273,7 @@ class CryoDrgnProtTrain(ProtProcessParticles):
         """
         zEpochFile = self.getEpochZFile(self._epoch)
         with open(zEpochFile, 'rb') as f:
-            zValues = pickle.load(f)
+            zValues = iter(pickle.load(f))
         return zValues
 
     def _createParticleSet(self):
@@ -283,21 +283,21 @@ class CryoDrgnProtTrain(ProtProcessParticles):
         """
         cryoDRGParticles = self.inputParticles.get()
         ImgSet = self.getProject().getProtocol(cryoDRGParticles.getObjParentId()).inputParticles.get()
+        zValues = self._getParticlesZvalues()
         outImgSet = self._createSetOfParticles()
         outImgSet.copyInfo(ImgSet)
-        outImgSet.copyItems(ImgSet, updateItemCallback=self._setZValues)
-
+        outImgSet.copyItems(ImgSet, updateItemCallback=self._setZValues,
+                            itemDataIterator=zValues)
         setattr(outImgSet, WEIGHTS, pwobj.String(self._getFileName('weights')))
         setattr(outImgSet, CONFIG, pwobj.String(self._getFileName('config')))
 
         return outImgSet
 
     def _setZValues(self, item, row=None):
-        zValues = self._getParticlesZvalues()
         vector = pwobj.CsvList()
         # We assume that each row "i" of z_values corresponds to each
         # particle with ID "i"
-        vector._convertValue(list(zValues[item.getObjId()-1]))
+        vector._convertValue(list(row))
         setattr(item, Z_VALUES, vector)
 
     def _getVolumeZvalues(self, zValueFile):

--- a/cryodrgn/protocols/protocol_train.py
+++ b/cryodrgn/protocols/protocol_train.py
@@ -328,7 +328,10 @@ class CryoDrgnProtTrain(ProtProcessParticles):
             vector = pwobj.CsvList()
             # We assume that each row "i" of z_values corresponds to each
             # volumes with ID "i"
-            vector._convertValue(zValues[volId])
+            volZValues = zValues[volId]
+            if not isinstance(volZValues, list):  # Case when dim=1
+                volZValues = [volZValues]
+            vector._convertValue(volZValues)
             # Creating a new column in the volumes with the z_value
             setattr(vol, Z_VALUES, vector)
             if updateItemCallback:


### PR DESCRIPTION
* Fixing a bug related to zvalues and particle IDs:     
      - when the particle set is created from a subset and the ids of the set  are not consecutive, cryodrgn fails.